### PR TITLE
Solved Cisco logo not showing.

### DIFF
--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -11,6 +11,8 @@ let paths = {
     index: 'app/index.html',
     appSrc: ['app/**/*', '!app/index.html'],
     bowerSrc: 'bower_components/**/*',
+    
+    logo: '../cisco_logo.png'
 }
 
 gulp.task('default', ['watch']);
@@ -19,7 +21,7 @@ gulp.task('watch', ['serve'], function(){
     gulp.watch(paths.appSrc, ['scripts']);
     gulp.watch(paths.bowerSrc, ['vendors']);
     gulp.watch(paths.index, ['copyAll']);
-    gulp.src("../cisco_logo.png")
+    gulp.src(paths.logo)
         .pipe(gulp.dest(paths.temp));
 });
 

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -19,6 +19,8 @@ gulp.task('watch', ['serve'], function(){
     gulp.watch(paths.appSrc, ['scripts']);
     gulp.watch(paths.bowerSrc, ['vendors']);
     gulp.watch(paths.index, ['copyAll']);
+    gulp.src("../cisco_logo.png")
+        .pipe(gulp.dest(paths.temp));
 });
 
 gulp.task('serve', ['copyAll'], function(){


### PR DESCRIPTION
- Modified gulpfile.js to copy cisco_logo.png to paths.temp.