### PR TITLE
Added more styling for AngularJS DataTable

### DIFF
--- a/frontend/app/directives/display-ha-pairs/display-ha-pairs.css
+++ b/frontend/app/directives/display-ha-pairs/display-ha-pairs.css
@@ -1,14 +1,19 @@
-.ha-table > thead {
-    text-align: center;
-    font-size: larger;
-    font-weight: 700;
-    color: black;
-    background-color: #e2a90d;
+.ha-box {
+    margin: 1% 1% 0 1%; 
+    background-color: #073642;
+    border-radius: 10px;
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2),
+                0 6px 20px 0 rgba(0, 0, 0, 0.19);
 }
 
-.ha-table > tbody {
+.ha-table {
     color: black;
     text-align: center;
+}
+.ha-table > thead {
+    font-size: larger;
+    font-weight: 700;
+    background-color: #e2a90d;
 }
 
 table.dataTable > tbody > tr.child:hover {
@@ -19,16 +24,18 @@ table.dataTable > tbody > tr.child ul.dtr-details {
     width: 100%;
 }
 
-.row-table > thead {
-    text-align: center;
-    font-size: larger;
-    font-weight: 700;
+.row-table {
     color: black;
+    text-align: center;
 }
 
-.row-table  > tbody {
-    color: black;
-    text-align: center;
+.row-table > thead {
+    font-size: larger;
+    font-weight: 700;
+}
+
+.dataTables_wrapper {
+    margin: 0 0.5%;
 }
 
 .dataTables_wrapper .dataTables_paginate .paginate_button.disabled, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:hover, .dataTables_wrapper .dataTables_paginate .paginate_button.disabled:active {

--- a/frontend/app/directives/display-ha-pairs/display-ha-pairs.html
+++ b/frontend/app/directives/display-ha-pairs/display-ha-pairs.html
@@ -1,2 +1,4 @@
-<table datatable="" dt-options="showCase.dtOptions" dt-columns="showCase.dtColumns"
-    class="table table-bordered ha-table" width="100%"></table>
+<div class="ha-box">
+    <table datatable="" dt-options="showCase.dtOptions" dt-columns="showCase.dtColumns"
+        class="table table-bordered ha-table" width="100%"></table>
+</div>

--- a/frontend/app/directives/display-ha-pairs/display-ha-pairs.js
+++ b/frontend/app/directives/display-ha-pairs/display-ha-pairs.js
@@ -8,7 +8,6 @@
     /** @ngInject */
     function displayHaPairsDirective(DTOptionsBuilder, DTColumnBuilder) {
         function displayHaPairs() {
-            var info = "Abracadabra";
             var vm = this;
             vm.dtOptions = DTOptionsBuilder.newOptions()
                 .withOption('ajax', {


### PR DESCRIPTION
- Modified display_ha_pairs.css to add some box shadows and margins to the box that wraps the View HA Pairs datatable
- Modified display_ha_pairs.tmpl.html so that the datatable is wrapped by the ha-pair box
- Modified display_ha_pairs.ctrl.js to remove an unused variable